### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/src/pages/[id]/index.js
+++ b/src/pages/[id]/index.js
@@ -11,6 +11,13 @@ const PetPage = ({ pet }) => {
   const handleDelete = async () => {
     const petID = router.query.id
 
+    // Validate petID format
+    const isValidID = /^[a-fA-F0-9]{24}$/.test(petID);
+    if (!isValidID) {
+      setMessage('Invalid pet ID.');
+      return;
+    }
+
     try {
       await fetch(`/api/pets/${petID}`, {
         method: 'Delete',


### PR DESCRIPTION
Potential fix for [https://github.com/MasterOf-None/shellter_pets/security/code-scanning/1](https://github.com/MasterOf-None/shellter_pets/security/code-scanning/1)

To fix the problem, we need to ensure that the `petID` used in the `fetch` call is validated against a known set of valid IDs or sanitized to prevent any malicious input. One way to achieve this is to use a regular expression to validate the `petID` format before making the request. This ensures that only valid IDs are used in the URL, mitigating the risk of SSRF.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
