### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-azure-resources.yml
+++ b/.github/workflows/create-azure-resources.yml
@@ -1,5 +1,7 @@
 name: Create Azure resources
 on: [workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MasterOf-None/shellter_pets/security/code-scanning/3](https://github.com/MasterOf-None/shellter_pets/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the actions used in the workflow:
- `actions/checkout` requires `contents: read` to check out the repository code.
- The Azure-related actions (`azure/login` and `azure/arm-deploy`) do not require additional GitHub permissions as they rely on Azure credentials provided via secrets.

Thus, the minimal permissions required for this workflow are `contents: read`. This will be added at the root of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
