### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,6 +3,8 @@
     push:
       branches:
         - main
+  permissions:
+    contents: read
 
   jobs:
     deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/MasterOf-None/shellter_pets/security/code-scanning/4](https://github.com/MasterOf-None/shellter_pets/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the actions used in the workflow:
- `actions/checkout` requires `contents: read` to check out the repository code.
- `azure/login` and `azure/container-apps-deploy-action` do not require additional permissions beyond what is provided by the Azure credentials.

Thus, we will set `contents: read` as the minimal permission for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
